### PR TITLE
feat: custom timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ This module exposes a single function `download` which takes the same arguments 
 * **number_sample_per_shard** the number of sample that will be downloaded in one shard (default *10000*)
 * **save_metadata** if true, saves one parquet file per folder/tar and json files with metadata (default *True*)
 * **save_additional_columns** list of additional columns to take from the csv/parquet files and save in metadata files (default *None*)
+* **timeout** maximum time (in seconds) to wait when trying to download an image (default *10*)
 
 ## How to tweak the options
 


### PR DESCRIPTION
I think it can be useful to allow for custom timeout.

I'm thinking that on a new setup, we'll run an automated little search (easy to do with wandb) over number of threads, processes, timeout (and any other parameter) to log/compare performance (speed and success rate) with different parameters.