### PR TITLE
Optimize globing in downloader

### DIFF
--- a/img2dataset/downloader.py
+++ b/img2dataset/downloader.py
@@ -298,7 +298,7 @@ def download(
     save_caption = caption_col is not None
 
     if os.path.isdir(url_list):
-        input_files = list(sorted(glob.glob(url_list + "/*." + input_format)))
+        input_files = list(sorted(glob.iglob(url_list + "/*." + input_format)))
     else:
         input_files = [url_list]
 

--- a/img2dataset/downloader.py
+++ b/img2dataset/downloader.py
@@ -298,7 +298,7 @@ def download(
     save_caption = caption_col is not None
 
     if os.path.isdir(url_list):
-        input_files = list(sorted(glob.iglob(url_list + "/*." + input_format)))
+        input_files = sorted(glob.iglob(url_list + "/*." + input_format))
     else:
         input_files = [url_list]
 


### PR DESCRIPTION
Saw a recent commit and realized that this could be optimized. Will increase speed, reduce memory usage, and allow overlapping the file listing calls with the sorting. Sorted already returns a list so no need to copy all the elements in the list.