### PR TITLE
Enhance image resize processing (esp re downscale)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ This module exposes a single function `download` which takes the same arguments 
   * **keep_ratio** will keep the ratio and make the smallest side of the picture image_size
   * **center_crop** will keep the ratio and center crop the largest side so the picture is squared
 * **resize_only_if_bigger** resize pictures only if bigger that the image_size (default *False*)
+* **upscale_interpolation** kind of upscale interpolation used for resizing (default *"lanczos"*)
+* **downscale_interpolation** kind of downscale interpolation used for resizing (default *"area"*)
+* **encode_quality** encode quality (default *95*)
+* **skip_reencode** whether to skip reencoding if no resizing is done (default *False*)
 * **output_format** decides how to save pictures (default *files*)
   * **files** saves as a set of subfolder containing pictures
   * **webdataset** saves as tars containing pictures

--- a/img2dataset/downloader.py
+++ b/img2dataset/downloader.py
@@ -89,7 +89,7 @@ class Resizer:
     ):
         self.image_size = image_size
         if isinstance(resize_mode, str):
-            if resize_mode not in ResizeMode.__members__:
+            if resize_mode not in ResizeMode.__members__: #pylint: disable=unsupported-membership-test
                 raise Exception(f"Invalid option for resize_mode: {resize_mode}")
             resize_mode = ResizeMode[resize_mode]
         self.resize_mode = resize_mode

--- a/img2dataset/downloader.py
+++ b/img2dataset/downloader.py
@@ -78,18 +78,18 @@ class Resizer:
     """Resize images"""
 
     def __init__(
-            self,
-            image_size,
-            resize_mode,
-            resize_only_if_bigger,
-            upscale_interpolation="lanczos",
-            downscale_interpolation="area",
-            encode_quality=95,
-            skip_reencode=False
+        self,
+        image_size,
+        resize_mode,
+        resize_only_if_bigger,
+        upscale_interpolation="lanczos",
+        downscale_interpolation="area",
+        encode_quality=95,
+        skip_reencode=False,
     ):
         self.image_size = image_size
         if isinstance(resize_mode, str):
-            if resize_mode not in ResizeMode.__members__: #pylint: disable=unsupported-membership-test
+            if resize_mode not in ResizeMode.__members__:  # pylint: disable=unsupported-membership-test
                 raise Exception(f"Invalid option for resize_mode: {resize_mode}")
             resize_mode = ResizeMode[resize_mode]
         self.resize_mode = resize_mode
@@ -101,7 +101,7 @@ class Resizer:
 
     def __call__(self, img_stream):
         try:
-            encode_needed = imghdr.what(img_stream) != 'jpeg' if self.skip_reencode else True
+            encode_needed = imghdr.what(img_stream) != "jpeg" if self.skip_reencode else True
             img_buf = np.frombuffer(img_stream.read(), np.uint8)
             img = cv2.imdecode(img_buf, cv2.IMREAD_UNCHANGED)
             if img is None:
@@ -129,7 +129,8 @@ class Resizer:
                     interpolation = self.downscale_interpolation if downscale else self.upscale_interpolation
                     img = A.longest_max_size(img, self.image_size, interpolation=interpolation)
                     img = A.pad(
-                        img, self.image_size, self.image_size, border_mode=cv2.BORDER_CONSTANT, value=[255, 255, 255])
+                        img, self.image_size, self.image_size, border_mode=cv2.BORDER_CONSTANT, value=[255, 255, 255]
+                    )
                     encode_needed = True
             height, width = img.shape[:2]
             if encode_needed:

--- a/img2dataset/downloader.py
+++ b/img2dataset/downloader.py
@@ -1,5 +1,6 @@
 """Img2dataset"""
 
+from enum import Enum
 from multiprocessing import Pool
 from multiprocessing.pool import ThreadPool
 from threading import Semaphore
@@ -22,9 +23,36 @@ import glob
 import logging
 import time
 import wandb
+import imghdr
 from .logging_utils import CappedCounter, SpeedLogger, StatusTableLogger
 
 logging.getLogger("exifread").setLevel(level=logging.CRITICAL)
+
+
+_INTER_STR_TO_CV2 = dict(
+    nearest=cv2.INTER_NEAREST,
+    linear=cv2.INTER_LINEAR,
+    bilinear=cv2.INTER_LINEAR,
+    cubic=cv2.INTER_CUBIC,
+    bicubic=cv2.INTER_CUBIC,
+    area=cv2.INTER_AREA,
+    lanczos=cv2.INTER_LANCZOS4,
+    lanczos4=cv2.INTER_LANCZOS4,
+)
+
+
+class ResizeMode(Enum):
+    no = 0
+    keep_ratio = 1
+    center_crop = 2
+    border = 3
+
+
+def inter_str_to_cv2(inter_str):
+    inter_str = inter_str.lower()
+    if inter_str not in _INTER_STR_TO_CV2:
+        raise Exception(f"Invalid option for interpolation: {inter_str}")
+    return _INTER_STR_TO_CV2[inter_str]
 
 
 def download_image(row, timeout):
@@ -49,33 +77,33 @@ def download_image(row, timeout):
 class Resizer:
     """Resize images"""
 
-    def __init__(self, image_size, resize_mode, resize_only_if_bigger):
+    def __init__(
+            self,
+            image_size,
+            resize_mode,
+            resize_only_if_bigger,
+            upscale_interpolation="lanczos",
+            downscale_interpolation="area",
+            encode_quality=95,
+            skip_reencode=False
+    ):
         self.image_size = image_size
+        if isinstance(resize_mode, str):
+            if resize_mode not in ResizeMode.__members__:
+                raise Exception(f"Invalid option for resize_mode: {resize_mode}")
+            resize_mode = ResizeMode[resize_mode]
         self.resize_mode = resize_mode
         self.resize_only_if_bigger = resize_only_if_bigger
-
-        if resize_mode not in ["no", "keep_ratio", "center_crop", "border"]:
-            raise Exception(f"Invalid option for resize_mode: {resize_mode}")
-
-        if resize_mode == "keep_ratio":
-            self.resize_tfm = A.SmallestMaxSize(image_size, interpolation=cv2.INTER_LANCZOS4)
-        elif resize_mode == "center_crop":
-            self.resize_tfm = A.Compose(
-                [A.SmallestMaxSize(image_size, interpolation=cv2.INTER_LANCZOS4), A.CenterCrop(image_size, image_size),]
-            )
-        elif resize_mode == "border":
-            self.resize_tfm = A.Compose(
-                [
-                    A.LongestMaxSize(image_size, interpolation=cv2.INTER_LANCZOS4),
-                    A.PadIfNeeded(image_size, image_size, border_mode=cv2.BORDER_CONSTANT, value=[255, 255, 255],),
-                ]
-            )
-        elif resize_mode == "no":
-            pass
+        self.upscale_interpolation = inter_str_to_cv2(upscale_interpolation)
+        self.downscale_interpolation = inter_str_to_cv2(downscale_interpolation)
+        self.encode_params = [int(cv2.IMWRITE_JPEG_QUALITY), encode_quality]
+        self.skip_reencode = skip_reencode
 
     def __call__(self, img_stream):
         try:
-            img = cv2.imdecode(np.frombuffer(img_stream.read(), np.uint8), cv2.IMREAD_UNCHANGED)
+            encode_needed = imghdr.what(img_stream) != 'jpeg' if self.skip_reencode else True
+            img_buf = np.frombuffer(img_stream.read(), np.uint8)
+            img = cv2.imdecode(img_buf, cv2.IMREAD_UNCHANGED)
             if img is None:
                 raise Exception("Image decoding error")
             if len(img.shape) == 3 and img.shape[-1] == 4:
@@ -83,27 +111,31 @@ class Resizer:
                 alpha = img[:, :, 3, np.newaxis]
                 img = alpha / 255 * img[..., :3] + 255 - alpha
                 img = np.rint(img.clip(min=0, max=255)).astype(np.uint8)
+                encode_needed = True
             original_height, original_width = img.shape[:2]
 
             # resizing in following conditions
-            if self.resize_mode != "no" and (
-                not self.resize_only_if_bigger
-                or (
-                    self.resize_mode in ["keep_ratio", "center_crop"]
-                    # smallest side contained to image_size (largest cropped)
-                    and min(img.shape[:2]) > self.image_size
-                )
-                or (
-                    self.resize_mode == "border"
-                    # largest side contained to image_size
-                    and max(img.shape[:2]) > self.image_size
-                )
-            ):
-                img = self.resize_tfm(image=img)["image"]
-
+            if self.resize_mode in (ResizeMode.keep_ratio, ResizeMode.center_crop):
+                downscale = min(original_width, original_height) > self.image_size
+                if not self.resize_only_if_bigger or downscale:
+                    interpolation = self.downscale_interpolation if downscale else self.upscale_interpolation
+                    img = A.smallest_max_size(img, self.image_size, interpolation=interpolation)
+                    if self.resize_mode == ResizeMode.center_crop:
+                        img = A.center_crop(img, self.image_size, self.image_size)
+                    encode_needed = True
+            elif self.resize_mode == ResizeMode.border:
+                downscale = max(original_width, original_height) > self.image_size
+                if not self.resize_only_if_bigger or downscale:
+                    interpolation = self.downscale_interpolation if downscale else self.upscale_interpolation
+                    img = A.longest_max_size(img, self.image_size, interpolation=interpolation)
+                    img = A.pad(
+                        img, self.image_size, self.image_size, border_mode=cv2.BORDER_CONSTANT, value=[255, 255, 255])
+                    encode_needed = True
             height, width = img.shape[:2]
-            img_str = cv2.imencode(".jpg", img)[1].tobytes()
-            del img
+            if encode_needed:
+                img_str = cv2.imencode(".jpg", img, params=self.encode_params)[1].tobytes()
+            else:
+                img_str = img_buf.tobytes()
             return img_str, width, height, original_width, original_height, None
 
         except Exception as err:  # pylint: disable=broad-except
@@ -306,6 +338,10 @@ def download(
     processes_count: int = 1,
     resize_mode: str = "border",
     resize_only_if_bigger: bool = False,
+    upscale_interpolation: str = "lanczos",
+    downscale_interpolation: str = "area",
+    encode_quality: int = 95,
+    skip_reencode: bool = False,
     output_format: str = "files",
     input_format: str = "txt",
     url_col: str = "url",
@@ -374,6 +410,8 @@ def download(
                 column_list = column_list + ["url"]
             images_to_dl = df[column_list].to_records(index=False).tolist()
             del df
+        else:
+            assert False, f"Unexpected input format ({input_format})."
 
         sharded_images_to_dl = []
         number_samples = len(images_to_dl)
@@ -393,7 +431,15 @@ def download(
         elif output_format == "files":
             sample_writer_class = FilesSampleWriter  # type: ignore
 
-        resizer = Resizer(image_size=image_size, resize_mode=resize_mode, resize_only_if_bigger=resize_only_if_bigger,)
+        resizer = Resizer(
+            image_size=image_size,
+            resize_mode=resize_mode,
+            resize_only_if_bigger=resize_only_if_bigger,
+            upscale_interpolation=upscale_interpolation,
+            downscale_interpolation=downscale_interpolation,
+            encode_quality=encode_quality,
+            skip_reencode=skip_reencode,
+        )
 
         downloader = functools.partial(
             one_process_downloader,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -104,18 +104,22 @@ def check_image_size(file_list, l_unresized, image_size, resize_mode, resize_onl
 
 
 testdata = [
-    ("border", False),
-    ("border", True),
-    ("keep_ratio", True),
-    ("keep_ratio", False),
-    ("center_crop", True),
-    ("center_crop", False),
-    ("no", False),
+    ("border", False, False),
+    ("border", False, True),
+    ("border", True, False),
+    ("keep_ratio", False, False),
+    ("keep_ratio", True, False),
+    ("keep_ratio", True, True),
+    ("center_crop", False, False),
+    ("center_crop", True, False),
+    ("no", False, False),
+    ("no", False, True),
 ]
 
 
-@pytest.mark.parametrize("resize_mode, resize_only_if_bigger", testdata)
-def test_download_resize(resize_mode, resize_only_if_bigger):
+@pytest.mark.parametrize("image_size", [256, 512])
+@pytest.mark.parametrize("resize_mode, resize_only_if_bigger, skip_reencode", testdata)
+def test_download_resize(image_size, resize_mode, resize_only_if_bigger, skip_reencode):
     prefix = resize_mode + "_" + str(resize_only_if_bigger) + "_"
     url_list_name = os.path.join(test_folder, prefix + "url_list.txt")
     image_folder_name = os.path.join(test_folder, prefix + "images")
@@ -125,7 +129,7 @@ def test_download_resize(resize_mode, resize_only_if_bigger):
 
     download(
         url_list_name,
-        image_size=256,
+        image_size=image_size,
         output_folder=unresized_folder,
         thread_count=32,
         resize_mode="no",
@@ -134,11 +138,12 @@ def test_download_resize(resize_mode, resize_only_if_bigger):
 
     download(
         url_list_name,
-        image_size=256,
+        image_size=image_size,
         output_folder=image_folder_name,
         thread_count=32,
         resize_mode=resize_mode,
         resize_only_if_bigger=resize_only_if_bigger,
+        skip_reencode=skip_reencode,
     )
 
     l = get_all_files(image_folder_name, "jpg")
@@ -148,7 +153,7 @@ def test_download_resize(resize_mode, resize_only_if_bigger):
     assert len(p) == 1
     l_unresized = get_all_files(unresized_folder, "jpg")
     assert len(l) == len(test_list)
-    check_image_size(l, l_unresized, 256, resize_mode, resize_only_if_bigger)
+    check_image_size(l, l_unresized, image_size, resize_mode, resize_only_if_bigger)
 
     os.remove(url_list_name)
     shutil.rmtree(image_folder_name)


### PR DESCRIPTION
* add support for different downsample and upsample interpolation (area only interpolation for dowsample that is reasonable without extra filtering as Pillow does)
* add ability to skip re-encode for jpg data with size that fits target already (reduce CPU and avoid quality loss for an unecessary encode)
* pass jpeg encode quality through as arg, cv2 default is 95, lower is likely good enough for many uses (and far less impact than bad downsample choice)
* ResizeMode enum instead of strings
* use functional Albumentations for resize ops