### PR TITLE
make the reader emits file paths instead of samples

### DIFF
--- a/img2dataset/architecture.md
+++ b/img2dataset/architecture.md
@@ -1,9 +1,9 @@
 Img2dataset is split in these modules:
 
-* reader: read the url data and yield it as shards
+* reader: read the url data and yield it as file shards (list of arrow files)
 * writer: write the image data
 * resizer: take as input images, and return resized images
-* downloader: takes one shard, resize it using the resizer, write it using the writer
+* downloader: takes one shard, read it to memory, resize it using the resizer, write it using the writer
 * main: takes a collection of files, reads them as shards using the reader, spawn N processes and in each use a downloader to process shards
 
 Main is the only one that is exposed to the user

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -5,6 +5,7 @@ from img2dataset.writer import FilesSampleWriter
 from img2dataset.downloader import Downloader
 
 import os
+import pandas as pd
 
 
 def test_downloader():
@@ -30,7 +31,11 @@ def test_downloader():
         compute_md5=True,
     )
 
-    downloader((0, list(enumerate(test_list))))
+    tmp_file = os.path.join(test_folder, "test_list.feather")
+    df = pd.DataFrame(test_list, columns=["caption", "url"])
+    df.to_feather(tmp_file)
+
+    downloader((0, tmp_file))
 
     assert len(os.listdir(image_folder_name + "/00000")) == 3 * len(test_list)
 


### PR DESCRIPTION
makes the downloader read the files itself
these arrow/feather files are then deleted when not needed anymore

this makes it much more straight forward to let workers run on other machines
these workers can directly read the shards from a distributed file system

this also decreases ram usage a bit