### PR TITLE
make total logging more intuitive and convenient by logging every worker return

### DIFF
--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -57,7 +57,7 @@ def download(
     output_folder = make_path_absolute(output_folder)
     url_list = make_path_absolute(url_list)
 
-    logger_process = LoggerProcess(output_folder, enable_wandb, wandb_project, config_parameters, processes_count)
+    logger_process = LoggerProcess(output_folder, enable_wandb, wandb_project, config_parameters)
     logger_process.start()
 
     tmp_path = output_folder + "/_tmp"


### PR DESCRIPTION
the beginning is slower but this is the true value

in another PR, I may add an estimation of the sample/s based on the number of workers
it might also make sense to start the total at the start of the first worker
(for example by storing and reading the minimal start time in the stat json files)