### PR TITLE
do not use listing caching in logger

### DIFF
--- a/img2dataset/logger.py
+++ b/img2dataset/logger.py
@@ -199,7 +199,7 @@ class LoggerProcess(multiprocessing.context.SpawnProcess):
     def run(self):
         """Run logger process"""
 
-        fs, output_path = fsspec.core.url_to_fs(self.output_folder)
+        fs, output_path = fsspec.core.url_to_fs(self.output_folder, use_listings_cache=False)
 
         if self.enable_wandb:
             self.current_run = wandb.init(project=self.wandb_project, config=self.config_parameters, anonymous="allow")


### PR DESCRIPTION
see https://filesystem-spec.readthedocs.io/en/latest/features.html?highlight=refresh#listings-caching

fixes logger on aws s3