### PR TITLE
force one thread for opencv

### DIFF
--- a/img2dataset/resizer.py
+++ b/img2dataset/resizer.py
@@ -73,6 +73,7 @@ class Resizer:
         output: img_str, width, height, original_width, original_height, err
         """
         try:
+            cv2.setNumThreads(1)
             encode_needed = imghdr.what(img_stream) != "jpeg" if self.skip_reencode else True
             img_buf = np.frombuffer(img_stream.read(), np.uint8)
             img = cv2.imdecode(img_buf, cv2.IMREAD_UNCHANGED)


### PR DESCRIPTION
in some environments, multiple threads are used by opencv

this is not a good property as multicore is already handled by the distributor

this speeds up the process and uses less cpu