### PR TITLE
make metadata writer much faster by building the schema in the downloader instead of guessing it

### DIFF
--- a/img2dataset/logger.py
+++ b/img2dataset/logger.py
@@ -7,6 +7,7 @@ import fsspec
 import json
 import multiprocessing
 import queue
+import traceback
 
 
 class CappedCounter:
@@ -272,7 +273,8 @@ class LoggerProcess(multiprocessing.context.SpawnProcess):
                     self.finish()
                     return
             except Exception as e:  # pylint: disable=broad-except
-                print(e)
+                traceback.print_exc()
+                print("logger error", e)
                 self.finish()
                 return
 

--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -83,7 +83,7 @@ def download(
         fs.mkdir(output_path)
         start_shard_id = 0
     else:
-        existing_top_level_files = [x for x in fs.glob(output_path + "/*") if x != tmp_dir]
+        existing_top_level_files = [x for x in fs.glob(output_path + "/*") if x != tmp_dir and "stats" not in x]
         if len(existing_top_level_files) == 0:
             start_shard_id = 0
         else:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -108,6 +108,31 @@ def test_download_input_format(input_format, output_format, tmp_path):
         caption_col="caption",
     )
 
+    if output_format != "dummy":
+
+        df = pd.read_parquet(image_folder_name + "/00000.parquet")
+
+        expected_columns = [
+            "url",
+            "key",
+            "status",
+            "error_message",
+            "width",
+            "height",
+            "original_width",
+            "original_height",
+            "exif",
+            "md5",
+        ]
+
+        if input_format != "txt":
+            expected_columns.insert(2, "caption")
+
+        if output_format == "parquet":
+            expected_columns.append("jpg")
+
+        assert set(df.columns.tolist()) == set(expected_columns)
+
     expected_file_count = len(test_list)
     if output_format == "files":
         l = get_all_files(image_folder_name, "jpg")


### PR DESCRIPTION
this makes it possible to garanty the buffer is written every 100 steps
avoids conversion to pandas which was using multiple threads

overall this increases the speed of img2dataset by 15%
and makes the cpu usage much easier to understand (mostly resizing)

this commit also includes some better exception logging, improvement of
tests and a small bug fix when continuing a download in main.py

a follow up of this might be to use pyarrow only and drop pandas