### PR TITLE
add new option allowing to disable reencoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ This module exposes a single function `download` which takes the same arguments 
   * **pyspark** use a pyspark session to create workers on a spark cluster (see details below)
 * **subjob_size** the number of shards to download in each subjob supporting it, a subjob can be a pyspark job for example (default *1000*)
 * **retries** number of time a download should be retried (default *0*)
+* **disable_all_reencoding** if set to True, this will keep the image files in their original state with no resizing and no conversion, will not even check if the image is valid. Useful for benchmarks. To use only if you plan to post process the images by another program and you have plenty of storage available. (default *False*)
 
 ## How to tweak the options
 
@@ -137,6 +138,11 @@ The default values should be good enough for small sized dataset. For larger one
 * increase thread_count as long as your bandwidth and cpu are below the limits
 * I advise to set output_format to webdataset if your dataset has more than 1M elements, it will be easier to manipulate few tars rather than million of files
 * keeping metadata to True can be useful to check what items were already saved and avoid redownloading them
+
+To benchmark your system, and img2dataset interactions with it, it may be interesting to enable these options (only for testing, not for real downloads)
+* --output_format dummy : will not save anything. Good to remove the storage bottleneck
+* --disable_all_reencoding True : will not reencode anything. Good to remove the cpu bottleneck
+When both these options are enabled, the only bottlenecks left are network related: eg dns setup, your bandwidth or the url servers bandwidth.
 
 ## File system support
 

--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -44,6 +44,7 @@ def download(
     distributor: str = "multiprocessing",
     subjob_size: int = 1000,
     retries: int = 0,
+    disable_all_reencoding: bool = False,
 ):
     """Download is the main entry point of img2dataset, it uses multiple processes and download multiple files"""
     config_parameters = dict(locals())
@@ -119,6 +120,7 @@ def download(
         downscale_interpolation=downscale_interpolation,
         encode_quality=encode_quality,
         skip_reencode=skip_reencode,
+        disable_all_reencoding=disable_all_reencoding,
     )
 
     downloader = Downloader(

--- a/img2dataset/resizer.py
+++ b/img2dataset/resizer.py
@@ -87,6 +87,7 @@ class Resizer:
         downscale_interpolation="area",
         encode_quality=95,
         skip_reencode=False,
+        disable_all_reencoding=False,
     ):
         self.image_size = image_size
         if isinstance(resize_mode, str):
@@ -99,6 +100,7 @@ class Resizer:
         self.downscale_interpolation = inter_str_to_cv2(downscale_interpolation)
         self.encode_params = [int(cv2.IMWRITE_JPEG_QUALITY), encode_quality]
         self.skip_reencode = skip_reencode
+        self.disable_all_reencoding = disable_all_reencoding
 
     def __call__(self, img_stream):
         """
@@ -106,6 +108,8 @@ class Resizer:
         output: img_str, width, height, original_width, original_height, err
         """
         try:
+            if self.disable_all_reencoding:
+                return img_stream.read(), None, None, None, None, None
             with SuppressStdoutStderr():
                 cv2.setNumThreads(1)
                 encode_needed = imghdr.what(img_stream) != "jpeg" if self.skip_reencode else True


### PR DESCRIPTION
this allows benchmarking img2dataset speed when no cpu constraint is there

--disable_all_reencoding True

I observed about +45% speed in this mode

fix #56 