### PR TITLE
use exifread-nocycle to avoid cycle in exifread

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ fire
 webdataset
 pandas
 pyarrow
-exifread
+exifread-nocycle
 albumentations
 pyyaml
 dataclasses


### PR DESCRIPTION
was causing infinite loop in some rare cases
see https://github.com/ianare/exif-py/pull/162/files