### PR TITLE
feat: support tfrecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ This module exposes a single function `download` which takes the same arguments 
   * **files** saves as a set of subfolder containing pictures
   * **webdataset** saves as tars containing pictures
   * **parquet** saves as parquet containing pictures as bytes
+  * **tfrecord** saves as tfrecord containing pictures as bytes
   * **dummy** does not save. Useful for benchmarks
 * **input_format** decides how to load the urls (default *txt*)
   * **txt** loads the urls as a text file of url, one per line

--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -5,7 +5,13 @@ import fire
 import logging
 from .logger import LoggerProcess
 from .resizer import Resizer
-from .writer import WebDatasetSampleWriter, FilesSampleWriter, ParquetSampleWriter, DummySampleWriter
+from .writer import (
+    WebDatasetSampleWriter,
+    FilesSampleWriter,
+    ParquetSampleWriter,
+    TFRecordSampleWriter,
+    DummySampleWriter,
+)
 from .reader import Reader
 from .downloader import Downloader
 from .distributor import multiprocessing_distributor, pyspark_distributor
@@ -111,6 +117,8 @@ def download(
         sample_writer_class = ParquetSampleWriter  # type: ignore
     elif output_format == "files":
         sample_writer_class = FilesSampleWriter  # type: ignore
+    elif output_format == "tfrecord":
+        sample_writer_class = TFRecordSampleWriter  # type: ignore
     elif output_format == "dummy":
         sample_writer_class = DummySampleWriter  # type: ignore
 

--- a/img2dataset/writer.py
+++ b/img2dataset/writer.py
@@ -147,7 +147,7 @@ class TFRecordSampleWriter:
         """Write a sample using tfrecord writer"""
         if img_str is not None:
             sample = {
-                "__key__": self._bytes_feature(key.encode()),
+                "key": self._bytes_feature(key.encode()),
                 "jpg": self._bytes_feature(img_str),
             }
             if self.save_caption:

--- a/img2dataset/writer.py
+++ b/img2dataset/writer.py
@@ -113,7 +113,8 @@ class TFRecordSampleWriter:
     def __init__(self, shard_id, output_folder, save_caption, oom_shard_count, schema):
         try:
             os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
-            from tensorflow.python.training.training import (
+            import tensorflow_io as _  # pylint: disable=import-outside-toplevel
+            from tensorflow.python.training.training import (  # pylint: disable=import-outside-toplevel
                 BytesList,
                 Int64List,
                 FloatList,
@@ -121,17 +122,18 @@ class TFRecordSampleWriter:
                 Features,
                 Feature,
             )
-            from tensorflow.python.lib.io.tf_record import TFRecordWriter
+            from tensorflow.python.lib.io.tf_record import TFRecordWriter  # pylint: disable=import-outside-toplevel
 
-            self._BytesList = BytesList
-            self._Int64List = Int64List
-            self._FloatList = FloatList
-            self._Example = Example
-            self._Features = Features
-            self._Feature = Feature
+            self._BytesList = BytesList  # pylint: disable=invalid-name
+            self._Int64List = Int64List  # pylint: disable=invalid-name
+            self._FloatList = FloatList  # pylint: disable=invalid-name
+            self._Example = Example  # pylint: disable=invalid-name
+            self._Features = Features  # pylint: disable=invalid-name
+            self._Feature = Feature  # pylint: disable=invalid-name
         except ImportError as e:
             raise ModuleNotFoundError(
-                "tfrecords require tensorflow to be installed. Run `pip install tensorflow`."
+                "tfrecords require tensorflow and tensorflow_io to be installed."
+                "Run `pip install tensorflow tensorflow_io`."
             ) from e
 
         self.oom_shard_count = oom_shard_count

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,3 +9,4 @@ pyspark
 uvicorn
 fastapi
 tensorflow
+tensorflow_io

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,3 +8,4 @@ psutil
 pyspark
 uvicorn
 fastapi
+tensorflow

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -85,6 +85,7 @@ def test_download_resize(image_size, resize_mode, resize_only_if_bigger, skip_re
         ["parquet", "webdataset"],
         ["parquet", "parquet"],
         ["parquet", "dummy"],
+        ["parquet", "tfrecord"],
     ],
 )
 def test_download_input_format(input_format, output_format, tmp_path):
@@ -157,6 +158,11 @@ def test_download_input_format(input_format, output_format, tmp_path):
     elif output_format == "dummy":
         l = [x for x in glob.glob(image_folder_name + "/*") if not x.endswith(".json")]
         assert len(l) == 0
+    elif output_format == "tfrecord":
+        l = glob.glob(image_folder_name + "/*.tfrecord")
+        assert len(l) == 1
+        if l[0] != image_folder_name + "/00000.tfrecord":
+            raise Exception(l[0] + " is not 00000.tfrecord")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add support for tfrecords.

The webdataset format is not very convenient on TPU's due to bad support of pytorch dataloaders in multiprocessing at the moment so tfrecords allow better usage of CPU's.