### PR TITLE
feat: accept numpy arrays

### DIFF
--- a/img2dataset/writer.py
+++ b/img2dataset/writer.py
@@ -98,6 +98,7 @@ class WebDatasetSampleWriter:
         self.buffered_parquet_writer = BufferedParquetWriter(output_folder + "/" + shard_name + ".parquet", schema, 100)
 
     def write(self, img_str, key, caption, meta):
+        """write sample to tars"""
         if img_str is not None:
             sample = {"__key__": key, "jpg": img_str}
             if self.save_caption:
@@ -226,6 +227,10 @@ class FilesSampleWriter:
                 with self.fs.open(caption_filename, "w") as f:
                     f.write(str(caption))
 
+            # some meta data may not be JSON serializable
+            for k, v in meta.items():
+                if isinstance(v, np.ndarray):
+                    meta[k] = v.tolist()
             j = json.dumps(meta, indent=4)
             meta_filename = f"{self.subfolder}/{key}.json"
             with self.fs.open(meta_filename, "w") as f:

--- a/img2dataset/writer.py
+++ b/img2dataset/writer.py
@@ -6,6 +6,7 @@ import pyarrow.parquet as pq
 import pyarrow as pa
 import fsspec
 import os
+import numpy as np
 
 
 class BufferedParquetWriter:
@@ -101,6 +102,10 @@ class WebDatasetSampleWriter:
             sample = {"__key__": key, "jpg": img_str}
             if self.save_caption:
                 sample["txt"] = str(caption) if caption is not None else ""
+            # some meta data may not be JSON serializable
+            for k, v in meta.items():
+                if isinstance(v, np.ndarray):
+                    meta[k] = v.tolist()
             sample["json"] = json.dumps(meta, indent=4)
             self.tarwriter.write(sample)
         self.buffered_parquet_writer.write(meta)


### PR DESCRIPTION
When parquet files contain lists, they are saved as numpy arrays.
It creates an issue if we want to save them with `save_additional_columns` because they are not JSON serializable.
We convert them into lists to avoid this issue.