### PR TITLE
Possible bug fix: resume always loop in zero shards number for all files

### DIFF
--- a/img2dataset/reader.py
+++ b/img2dataset/reader.py
@@ -151,7 +151,7 @@ class Reader:
 
         del df
 
-        return shards
+        return shards, number_shards
 
     def __iter__(self):
         """

--- a/img2dataset/reader.py
+++ b/img2dataset/reader.py
@@ -108,7 +108,7 @@ class Reader:
             if start_shard_id + shard_id not in self.done_shards
         ]
         if len(shards_to_write) == 0:
-            return []
+            return [], number_shards
 
         def write_shard(t):
             full_shard_id, shard_id = t
@@ -164,7 +164,7 @@ class Reader:
         for i, input_file in enumerate(self.input_files):
             print("Sharding file number " + str(i + 1) + " of " + str(len(self.input_files)) + " called " + input_file)
 
-            shards = self._save_to_arrow(input_file, start_shard_id)
+            shards, number_shards = self._save_to_arrow(input_file, start_shard_id)
             print("File sharded in " + str(len(shards)) + " shards")
             print(
                 "Downloading starting now, check your bandwidth speed (with bwm-ng)"
@@ -176,4 +176,4 @@ class Reader:
                     shard_id,
                     arrow_file,
                 )
-            start_shard_id += len(shards)
+            start_shard_id += number_shards


### PR DESCRIPTION
Problem encountered: when resume from a interrupted download, all shards in all files are treated as done_shards

start_shard_id is init as 0, and goes to _save_to_arrow, which is fine both for new download or resume

```
start_shard_id = 0
        for i, input_file in enumerate(self.input_files):
            print("Sharding file number " + str(i + 1) + " of " + str(len(self.input_files)) + " called " + input_file)

            shards = self._save_to_arrow(input_file, start_shard_id)
```

when _save_to_arrow tries to avoid self.done_shards, no shards to write, still good, return a empty list seems fine

```
        number_shards = math.ceil(df.num_rows / self.number_sample_per_shard)
        shards_to_write = [
            (start_shard_id + shard_id, shard_id)
            for shard_id in range(number_shards)
            if start_shard_id + shard_id not in self.done_shards
        ]
        if len(shards_to_write) == 0:
            return []
```

but if _save_to_arrow returns a empty list when resuming, `start_shard_id += len(shards)` would be zero, and always zero, because start_shard_id never adds up the real number_shards, I am fixing this myself by returning number_shards as well, 

```
    def __iter__(self):
        """
        Iterate over shards, yield shards of size number_sample_per_shard or less for the last one
        Each shard is a tuple (shard_id, shard)
        shard is a tuple (sample id, sample)
        sample is a tuple of the columns
        """
        start_shard_id = 0
        for i, input_file in enumerate(self.input_files):
            print("Sharding file number " + str(i + 1) + " of " + str(len(self.input_files)) + " called " + input_file)

            shards = self._save_to_arrow(input_file, start_shard_id)
            print("File sharded in " + str(len(shards)) + " shards")
            print(
                "Downloading starting now, check your bandwidth speed (with bwm-ng)"
                "your cpu (with htop), and your disk usage (with iotop)!"
            )

            for shard_id, arrow_file in shards:
                yield (
                    shard_id,
                    arrow_file,
                )
            start_shard_id += len(shards)
```

Haven't finished my downloading yet, not sure if everything works, additional tests are recommended before merging this fix