### PR TITLE
feat: allow encoding in different formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This module exposes a single function `download` which takes the same arguments 
 * **resize_only_if_bigger** resize pictures only if bigger that the image_size (default *False*)
 * **upscale_interpolation** kind of upscale interpolation used for resizing (default *"lanczos"*)
 * **downscale_interpolation** kind of downscale interpolation used for resizing (default *"area"*)
-* **encode_quality** encode quality (default *95*)
+* **encode_quality** encode quality from 0 to 100, when using png it is the compression factor from 0 to 9 (default *95*)
 * **encode_format** encode format (default *jpg*)
   * **jpg** jpeg format
   * **png** png format
@@ -153,6 +153,28 @@ Img2dataset support several formats. There are trade off for which to choose:
 * webdataset: webdataset format saves samples in tar files, thanks to [webdataset](https://webdataset.github.io/webdataset/) library, this makes it possible to load the resulting dataset fast in both pytorch, tensorflow and jax. Choose this for most use cases. It works well for any filesystem
 * parquet: parquet is a columnar format that allows fast filtering. It's particularly easy to read it using pyarrow and pyspark. Choose this if the rest of your data ecosystem is based on pyspark. [petastorm](https://github.com/uber/petastorm) can be used to read the data but it's not as easy to use as webdataset
 * tfrecord: tfrecord is a protobuf based format. It's particularly easy to use from tensorflow and using [tf data](https://www.tensorflow.org/guide/data). Use this if you plan to use the dataset only in the tensorflow ecosystem. The tensorflow writer does not use fsspec and as a consequence supports only a limited amount of filesystem, including local, hdfs, s3 and gcs. It is also less efficient than the webdataset writer when writing to other filesystems than local, losing some 30% performance.
+
+## Encode format choice
+
+Images can be encoded in jpeg, png or webp, with diffent quality settings.
+
+Here are a few comparisons of space used for 1M images at 256 x 256:
+
+| format | quality | compression | size (GB)  |
+| ------ | ------- | ----------- | ---------- |
+| jpg    | 100     | N/A         | 54.2       |
+| jpg    | 95      | N/A         | 29.9       |
+| png    | N/A     | 0           | 187.9      |
+| png    | N/A     | 9           | 97.7       |
+| webp   | 100     | N/A         | 31.0       |
+| webp   | 95      | N/A         | 23.8       |
+
+Notes:
+
+* jpeg at quality 100 is NOT lossless
+* png format is lossless
+* webp at quality 100 is lossless
+* same quality scale between formats does not mean same image quality
 
 ## How to tweak the options
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ This module exposes a single function `download` which takes the same arguments 
 * **upscale_interpolation** kind of upscale interpolation used for resizing (default *"lanczos"*)
 * **downscale_interpolation** kind of downscale interpolation used for resizing (default *"area"*)
 * **encode_quality** encode quality (default *95*)
+* **encode_format** encode format (default *jpg*)
+  * **jpg** jpeg format
+  * **png** png format
+  * **webp** webp format
 * **skip_reencode** whether to skip reencoding if no resizing is done (default *False*)
 * **output_format** decides how to save pictures (default *files*)
   * **files** saves as a set of subfolder containing pictures

--- a/img2dataset/downloader.py
+++ b/img2dataset/downloader.py
@@ -69,6 +69,7 @@ class Downloader:
         number_sample_per_shard,
         oom_shard_count,
         compute_md5,
+        encode_format,
         retries,
     ) -> None:
         self.sample_writer_class = sample_writer_class
@@ -82,6 +83,7 @@ class Downloader:
         self.number_sample_per_shard = number_sample_per_shard
         self.oom_shard_count = oom_shard_count
         self.compute_md5 = compute_md5
+        self.encode_format = encode_format
         self.retries = retries
 
     def __call__(
@@ -157,6 +159,7 @@ class Downloader:
             self.save_caption,
             self.oom_shard_count,
             schema,
+            self.encode_format,
         )
         oom_sample_per_shard = math.ceil(math.log10(self.number_sample_per_shard))
         with ThreadPool(self.thread_count) as thread_pool:

--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -133,7 +133,7 @@ def download(
     if encode_format == "png":
         if encode_quality < 0 or encode_quality > 9:
             raise ValueError(
-                f"For png, encode quality represents png compression which must be between 0 and 9, got {encode_quality}"
+                f"For png, encode quality represents compression which must be between 0 and 9, got {encode_quality}"
             )
 
     resizer = Resizer(

--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -33,6 +33,7 @@ def download(
     upscale_interpolation: str = "lanczos",
     downscale_interpolation: str = "area",
     encode_quality: int = 95,
+    encode_format: str = "jpg",
     skip_reencode: bool = False,
     output_format: str = "files",
     input_format: str = "txt",
@@ -127,6 +128,14 @@ def download(
     else:
         raise ValueError(f"Invalid output format {output_format}")
 
+    if encode_format not in ["jpg", "png", "webp"]:
+        raise ValueError(f"Invalid encode format {encode_format}")
+    if encode_format == "png":
+        if encode_quality < 0 or encode_quality > 9:
+            raise ValueError(
+                f"For png, encode quality represents png compression which must be between 0 and 9, got {encode_quality}"
+            )
+
     resizer = Resizer(
         image_size=image_size,
         resize_mode=resize_mode,
@@ -134,6 +143,7 @@ def download(
         upscale_interpolation=upscale_interpolation,
         downscale_interpolation=downscale_interpolation,
         encode_quality=encode_quality,
+        encode_format=encode_format,
         skip_reencode=skip_reencode,
         disable_all_reencoding=disable_all_reencoding,
     )
@@ -150,6 +160,7 @@ def download(
         number_sample_per_shard=number_sample_per_shard,
         oom_shard_count=oom_shard_count,
         compute_md5=compute_md5,
+        encode_format=encode_format,
         retries=retries,
     )
 

--- a/img2dataset/writer.py
+++ b/img2dataset/writer.py
@@ -158,9 +158,7 @@ class TFRecordSampleWriter:
                 Features,
                 Feature,
             )
-            from tensorflow.python.lib.io.tf_record import (
-                TFRecordWriter,
-            )  # pylint: disable=import-outside-toplevel
+            from tensorflow.python.lib.io.tf_record import TFRecordWriter  # pylint: disable=import-outside-toplevel
 
             self._BytesList = BytesList  # pylint: disable=invalid-name
             self._Int64List = Int64List  # pylint: disable=invalid-name

--- a/img2dataset/writer.py
+++ b/img2dataset/writer.py
@@ -280,7 +280,7 @@ class FilesSampleWriter:
 class DummySampleWriter:
     """Does not write"""
 
-    def __init__(self, shard_id, output_folder, save_caption, oom_shard_count, schema):
+    def __init__(self, shard_id, output_folder, save_caption, oom_shard_count, schema, encode_format):
         pass
 
     def write(self, img_str, key, caption, meta):

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -34,6 +34,7 @@ def test_unique_md5(tmp_path):
         number_sample_per_shard=10,
         oom_shard_count=5,
         compute_md5=True,
+        encode_format="jpg",
         retries=0,
     )
 
@@ -76,6 +77,7 @@ def test_downloader(tmp_path):
         number_sample_per_shard=10,
         oom_shard_count=5,
         compute_md5=True,
+        encode_format="jpg",
         retries=0,
     )
 

--- a/tests/test_resizer.py
+++ b/tests/test_resizer.py
@@ -29,7 +29,7 @@ testformat = [
 
 @pytest.mark.parametrize("image_size", [256, 512])
 @pytest.mark.parametrize("resize_mode, resize_only_if_bigger, skip_reencode", testdata)
-@pytest.mark.paremetrize("encode_quality, encode_format", testformat)
+@pytest.mark.parametrize("encode_quality, encode_format", testformat)
 def test_resizer(image_size, resize_mode, resize_only_if_bigger, skip_reencode, encode_quality, encode_format):
     current_folder = os.path.dirname(__file__)
     test_folder = current_folder + "/" + "resize_test_image"

--- a/tests/test_resizer.py
+++ b/tests/test_resizer.py
@@ -20,14 +20,28 @@ testdata = [
     ("no", False, True),
 ]
 
+testformat = [
+    (95, "jpg"),
+    (95, "webp"),
+    (9, "png"),
+]
+
 
 @pytest.mark.parametrize("image_size", [256, 512])
 @pytest.mark.parametrize("resize_mode, resize_only_if_bigger, skip_reencode", testdata)
-def test_resizer(image_size, resize_mode, resize_only_if_bigger, skip_reencode):
+@pytest.mark.paremetrize("encode_quality, encode_format", testformat)
+def test_resizer(image_size, resize_mode, resize_only_if_bigger, skip_reencode, encode_quality, encode_format):
     current_folder = os.path.dirname(__file__)
     test_folder = current_folder + "/" + "resize_test_image"
     image_paths = glob.glob(test_folder + "/*")
-    resizer = Resizer(image_size, resize_mode, resize_only_if_bigger, skip_reencode=skip_reencode)
+    resizer = Resizer(
+        image_size,
+        resize_mode,
+        resize_only_if_bigger,
+        encode_quality=encode_quality,
+        encode_format=encode_format,
+        skip_reencode=skip_reencode,
+    )
     for image_path in image_paths:
         with open(image_path, "rb") as f:
             img = f.read()

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -8,7 +8,6 @@ from img2dataset.writer import (
 
 import os
 import glob
-import shutil
 import pytest
 import tarfile
 import pandas as pd
@@ -46,7 +45,7 @@ def test_writer(writer_type, tmp_path):
     elif writer_type == "tfrecord":
         writer_class = TFRecordSampleWriter
 
-    writer = writer_class(0, output_folder, True, 5, schema)
+    writer = writer_class(0, output_folder, True, 5, schema, "jpg")
 
     for i, image_path in enumerate(image_paths):
         with open(image_path, "rb") as f:


### PR DESCRIPTION
Allows encoding in different formats:

* jpeg: default
* png
* webp

TODO:
* [ ] use it on some datasets: ongoing