### PR TITLE
Update README, working URL for parquet metadata

### DIFF
--- a/dataset_examples/laion-art.md
+++ b/dataset_examples/laion-art.md
@@ -14,7 +14,7 @@ https://huggingface.co/datasets/laion/laion2B-en-aesthetic
 https://huggingface.co/datasets/laion/laion2B-multi-aesthetic](https://huggingface.co/datasets/laion/laion-art)
 
 ```
-wget https://huggingface.co/datasets/laion/laion-art/resolve/main/laion-art.snappy.parquet
+wget https://huggingface.co/datasets/laion/laion-art/resolve/main/laion-art.parquet
 ```
 
 ### Download the images with img2dataset


### PR DESCRIPTION
# Fix Broken URL

The previous URL does not work. The only difference was removing the `.snappy.` file extension name.

### 404 Error for previous URL 
(https://huggingface.co/datasets/laion/laion-art/resolve/main/laion-art.snappy.parquet)
<img width="1019" alt="Screen Shot 2022-06-26 at 12 54 21 PM" src="https://user-images.githubusercontent.com/19615875/175827489-96546f91-06cc-45ca-b5c9-9fa3f8b69f47.png">

### Successful Download for new URL 
(https://huggingface.co/datasets/laion/laion-art/resolve/main/laion-art.parquet)
<img width="842" alt="Screen Shot 2022-06-26 at 12 55 04 PM" src="https://user-images.githubusercontent.com/19615875/175827509-226c52ea-f551-4e54-8540-34fa7df9de78.png">

