### PR TITLE
apply code formatting for install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Also supports saving captions for url+caption datasets.
 
 ## Install
 
+```
 pip install img2dataset
+```
 
 ## Examples
 


### PR DESCRIPTION
This is a small PR that proposes code formatting for `pip install img2dataset` in the readme.