### PR TITLE
feat: support min image size + max aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ This module exposes a single function `download` which takes the same arguments 
 * **subjob_size** the number of shards to download in each subjob supporting it, a subjob can be a pyspark job for example (default *1000*)
 * **retries** number of time a download should be retried (default *0*)
 * **disable_all_reencoding** if set to True, this will keep the image files in their original state with no resizing and no conversion, will not even check if the image is valid. Useful for benchmarks. To use only if you plan to post process the images by another program and you have plenty of storage available. (default *False*)
+* **min_image_size** minimum size of the image to download (default *0*)
+* **max_aspect_ratio** maximum aspect ratio of the image to download (default *inf*)
 * **incremental_mode** Can be "incremental" or "overwrite". For "incremental", img2dataset will download all the shards that were not downloaded, for "overwrite" img2dataset will delete recursively the output folder then start from zero (default *incremental*)
 * **max_shard_retry** Number of time to retry failed shards at the end (default *1*)
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,16 @@ Notes:
 * webp at quality 100 is lossless
 * same quality scale between formats does not mean same image quality
 
+## Filtering the dataset
+
+Whenever feasible, you should pre-filter your dataset prior to downloading.
+
+If needed, you can use:
+* --min_image_size SIZE : to filter out images with one side smaller than SIZE
+* --max_aspect_ratio RATIO : to filter out images with an aspect ratio greater than RATIO
+
+When filtering data, it is recommended to pre-shuffle your dataset to limit the impact on shard size distribution.
+
 ## How to tweak the options
 
 The default values should be good enough for small sized dataset. For larger ones, these tips may help you get the best performance:

--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -52,6 +52,8 @@ def download(
     subjob_size: int = 1000,
     retries: int = 0,
     disable_all_reencoding: bool = False,
+    min_image_size: int = 0,
+    max_aspect_ratio: float = float("inf"),
     incremental_mode: str = "incremental",
     max_shard_retry: int = 1,
 ):
@@ -146,6 +148,8 @@ def download(
         encode_format=encode_format,
         skip_reencode=skip_reencode,
         disable_all_reencoding=disable_all_reencoding,
+        min_image_size=min_image_size,
+        max_aspect_ratio=max_aspect_ratio,
     )
 
     downloader = Downloader(

--- a/img2dataset/resizer.py
+++ b/img2dataset/resizer.py
@@ -89,6 +89,8 @@ class Resizer:
         encode_format="jpg",
         skip_reencode=False,
         disable_all_reencoding=False,
+        min_image_size=0,
+        max_aspect_ratio=float("inf"),
     ):
         self.image_size = image_size
         if isinstance(resize_mode, str):
@@ -115,6 +117,8 @@ class Resizer:
         self.encode_params = [cv2_img_quality, encode_quality]
         self.skip_reencode = skip_reencode
         self.disable_all_reencoding = disable_all_reencoding
+        self.min_image_size = min_image_size
+        self.max_aspect_ratio = max_aspect_ratio
 
     def __call__(self, img_stream):
         """
@@ -140,6 +144,12 @@ class Resizer:
                     img = np.rint(img.clip(min=0, max=255)).astype(np.uint8)
                     encode_needed = True
                 original_height, original_width = img.shape[:2]
+                # check if image is too small
+                if min(original_height, original_width) < self.min_image_size:
+                    return None, None, None, None, None, "image too small"
+                # check if wrong aspect ratio
+                if max(original_height, original_width) / min(original_height, original_width) > self.max_aspect_ratio:
+                    return None, None, None, None, None, "aspect ratio too large"
 
                 # resizing in following conditions
                 if self.resize_mode in (ResizeMode.keep_ratio, ResizeMode.center_crop):

--- a/tests/test_resizer.py
+++ b/tests/test_resizer.py
@@ -60,3 +60,22 @@ def test_resizer(image_size, resize_mode, resize_only_if_bigger, skip_reencode, 
         assert width_original == original_width
         assert height_original == original_height
         check_one_image_size(image_resized, image_original, image_size, resize_mode, resize_only_if_bigger)
+
+
+def test_resizer_filter():
+    current_folder = os.path.dirname(__file__)
+    test_folder = current_folder + "/" + "resize_test_image"
+    image_paths = glob.glob(test_folder + "/*")
+    resizer = Resizer(
+        image_size=256, resize_mode="no", resize_only_if_bigger=True, min_image_size=200, max_aspect_ratio=1.5
+    )
+    errors = []
+    for image_path in image_paths:
+        with open(image_path, "rb") as f:
+            img = f.read()
+            image_original_stream = io.BytesIO(img)
+        _, _, _, _, _, err = resizer(image_original_stream)
+        errors.append(err)
+    expected_errors = [(None, 2), ("image too small", 2), ("aspect ratio too large", 3)]
+    for expected_error, count in expected_errors:
+        assert count == errors.count(expected_error)


### PR DESCRIPTION
This allows keeping only images above certain dimensions and with a max aspect ratio.
fixes #41

The limit on file sizes were not implemented as it may be less straightforward to justify.

TODO:
* [x] perform some manual tests