### PR TITLE
Reduce the download speed of single node

### DIFF
--- a/dataset_examples/laion400m.md
+++ b/dataset_examples/laion400m.md
@@ -18,6 +18,8 @@ img2dataset --url_list laion400m-meta --input_format "parquet"\
              --save_additional_columns '["NSFW","similarity","LICENSE"]' --enable_wandb True
 ```
 
+**Note: Please reduce the `thread_count` to 64 if you are using systemd-resolved, otherwise, your DNS server may stop working.**
+
 ### Benchmark
 
 This can be downloaded at 1300 sample/s so it takes 3.5 days to download with one 16 cores 2Gbps machine.


### PR DESCRIPTION
I tested the laion400m download script on different ubuntu 22.04 servers, and all resulted in lots of `<urlopen error [Errno -3] Temporary failure in name resolution>`. 

After checked the log of systems-resolved and found a discussion on [fedora](https://bugzilla.redhat.com/show_bug.cgi?id=2009980), I found that there is a maximum query limitation in [systemd resolved](https://github.com/systemd/systemd/blob/0e26016e3d00631d21ac3b0270aded1b51714845/src/resolve/resolved-dns-query.c). Thus, I create this pull request to warn people using systemd-resolved to reduce the downloading speed.
