### PR TITLE
add list of int, float feature in TFRecordSampleWriter

### DIFF
--- a/img2dataset/writer.py
+++ b/img2dataset/writer.py
@@ -151,10 +151,15 @@ class TFRecordSampleWriter:
         try:
             os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
             import tensorflow_io as _  # pylint: disable=import-outside-toplevel
-            from tensorflow.python.lib.io.tf_record import \
-                TFRecordWriter  # pylint: disable=import-outside-toplevel
+            from tensorflow.python.lib.io.tf_record import TFRecordWriter  # pylint: disable=import-outside-toplevel
             from tensorflow.python.training.training import (  # pylint: disable=import-outside-toplevel
-                BytesList, Example, Feature, Features, FloatList, Int64List)
+                BytesList,
+                Example,
+                Feature,
+                Features,
+                FloatList,
+                Int64List,
+            )
 
             self._BytesList = BytesList  # pylint: disable=invalid-name
             self._Int64List = Int64List  # pylint: disable=invalid-name
@@ -231,13 +236,12 @@ class TFRecordSampleWriter:
         elif isinstance(value[0], float):
             return self._Feature(float_list=self._FloatList(value=value))
         else:
-            for i, _bytes_feature in enumerate(value):
-                if _bytes_feature is None:
+            for i, bytes_feature in enumerate(value):
+                if bytes_feature is None:
                     value[i] = ""
-                if isinstance(_bytes_feature, str):
-                    value[i] = _bytes_feature.encode()
+                if isinstance(bytes_feature, str):
+                    value[i] = bytes_feature.encode()
             return self._Feature(bytes_list=self._BytesList(value=value))
-
 
 
 class FilesSampleWriter:

--- a/img2dataset/writer.py
+++ b/img2dataset/writer.py
@@ -225,15 +225,18 @@ class TFRecordSampleWriter:
         return self._Feature(int64_list=self._Int64List(value=[value]))
 
     def _list_feature(self, value):
-        """Returns an int64_list from a bool / enum / int / uint or float_list from a float / double."""
+        """Returns an list of int64_list, float_list, bytes_list."""
         if isinstance(value[0], int):
             return self._Feature(int64_list=self._Int64List(value=value))
         elif isinstance(value[0], float):
             return self._Feature(float_list=self._FloatList(value=value))
         else:
-            raise NotImplementedError(
-                "list feature can only have int64 or floats"
-            )
+            for i, _bytes_feature in enumerate(value):
+                if _bytes_feature is None:
+                    value[i] = ""
+                if isinstance(_bytes_feature, str):
+                    value[i] = _bytes_feature.encode()
+            return self._Feature(bytes_list=self._BytesList(value=value))
 
 
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -32,6 +32,7 @@ def test_writer(writer_type, tmp_path):
             pa.field("height", pa.int32()),
             pa.field("original_width", pa.int32()),
             pa.field("original_height", pa.int32()),
+            pa.field("labels", pa.list_(pa.int32())),
         ]
     )
     if writer_type == "files":
@@ -63,6 +64,7 @@ def test_writer(writer_type, tmp_path):
                     "height": 100,
                     "original_width": 100,
                     "original_height": 100,
+                    "labels": [0, 100, 200],
                 },
             )
     writer.close()
@@ -80,6 +82,7 @@ def test_writer(writer_type, tmp_path):
             "height",
             "original_width",
             "original_height",
+            "labels",
         ]
 
         if writer_type == "parquet":
@@ -95,6 +98,7 @@ def test_writer(writer_type, tmp_path):
         assert df["height"].iloc[0] == 100
         assert df["original_width"].iloc[0] == 100
         assert df["original_height"].iloc[0] == 100
+        assert (df["labels"].iloc[0] == [0, 100, 200]).all()
 
     if writer_type == "files":
         saved_files = list(glob.glob(output_folder + "/00000/*"))


### PR DESCRIPTION
We use list of int, list of float attribute in [coyo-labeled-300m](https://github.com/kakaobrain/coyo-dataset) dataset. (It will be released soon)
To create a dataset using img2dataset in tfrecord, we need to add above features.