### PR TITLE
added max_image_area flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ This module exposes a single function `download` which takes the same arguments 
 * **retries** number of time a download should be retried (default *0*)
 * **disable_all_reencoding** if set to True, this will keep the image files in their original state with no resizing and no conversion, will not even check if the image is valid. Useful for benchmarks. To use only if you plan to post process the images by another program and you have plenty of storage available. (default *False*)
 * **min_image_size** minimum size of the image to download (default *0*)
+* **max_image_area** maximum area of the image to download (default *inf*)
 * **max_aspect_ratio** maximum aspect ratio of the image to download (default *inf*)
 * **incremental_mode** Can be "incremental" or "overwrite". For "incremental", img2dataset will download all the shards that were not downloaded, for "overwrite" img2dataset will delete recursively the output folder then start from zero (default *incremental*)
 * **max_shard_retry** Number of time to retry failed shards at the end (default *1*)
@@ -192,6 +193,7 @@ Whenever feasible, you should pre-filter your dataset prior to downloading.
 
 If needed, you can use:
 * --min_image_size SIZE : to filter out images with one side smaller than SIZE
+* --max_image_area SIZE : to filter out images with area larger than SIZE
 * --max_aspect_ratio RATIO : to filter out images with an aspect ratio greater than RATIO
 
 When filtering data, it is recommended to pre-shuffle your dataset to limit the impact on shard size distribution.
@@ -391,7 +393,7 @@ to run tests:
 ```
 pip install -r requirements-test.txt
 ```
-then 
+then
 ```
 make lint
 make test

--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -53,6 +53,7 @@ def download(
     retries: int = 0,
     disable_all_reencoding: bool = False,
     min_image_size: int = 0,
+    max_image_area: float = float("inf"),
     max_aspect_ratio: float = float("inf"),
     incremental_mode: str = "incremental",
     max_shard_retry: int = 1,
@@ -151,6 +152,7 @@ def download(
         skip_reencode=skip_reencode,
         disable_all_reencoding=disable_all_reencoding,
         min_image_size=min_image_size,
+        max_image_area=max_image_area,
         max_aspect_ratio=max_aspect_ratio,
     )
 

--- a/img2dataset/resizer.py
+++ b/img2dataset/resizer.py
@@ -90,6 +90,7 @@ class Resizer:
         skip_reencode=False,
         disable_all_reencoding=False,
         min_image_size=0,
+        max_image_area=float("inf"),
         max_aspect_ratio=float("inf"),
     ):
         self.image_size = image_size
@@ -118,6 +119,7 @@ class Resizer:
         self.skip_reencode = skip_reencode
         self.disable_all_reencoding = disable_all_reencoding
         self.min_image_size = min_image_size
+        self.max_image_area = max_image_area
         self.max_aspect_ratio = max_aspect_ratio
 
     def __call__(self, img_stream):
@@ -147,6 +149,8 @@ class Resizer:
                 # check if image is too small
                 if min(original_height, original_width) < self.min_image_size:
                     return None, None, None, None, None, "image too small"
+                if original_height * original_width > self.max_image_area:
+                    return None, None, None, None, None, "image area too large"
                 # check if wrong aspect ratio
                 if max(original_height, original_width) / min(original_height, original_width) > self.max_aspect_ratio:
                     return None, None, None, None, None, "aspect ratio too large"

--- a/tests/test_resizer.py
+++ b/tests/test_resizer.py
@@ -79,3 +79,17 @@ def test_resizer_filter():
     expected_errors = [(None, 2), ("image too small", 2), ("aspect ratio too large", 3)]
     for expected_error, count in expected_errors:
         assert count == errors.count(expected_error)
+
+    resizer =  Resizer(
+        image_size=256, resize_mode="no", resize_only_if_bigger=True, max_image_area=60000
+    )
+    errors = []
+    for image_path in image_paths:
+        with open(image_path, "rb") as f:
+            img = f.read()
+            image_original_stream = io.BytesIO(img)
+        _, _, _, _, _, err = resizer(image_original_stream)
+        errors.append(err)
+    expected_errors = [(None, 2), ("image area too large", 5)]
+    for expected_error, count in expected_errors:
+        assert count == errors.count(expected_error)


### PR DESCRIPTION
Some libraries like `PIL` set a max image area size to prevent "decompression bomb DOS attack". Adding support to filter out images that exceed `max_image_area` in the `Resizer`