### PR TITLE
opencv-python => opencv-python-headless

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tqdm>=4.62.3,<5
-opencv-python>=4.5.5.62,<5
+opencv-python-headless>=4.5.5.62,<5
 fire>=0.4.0,<0.5.0
 webdataset>=0.2.5,<0.3
 pandas>=1.1.5,<2


### PR DESCRIPTION
This PR replaces `opencv-python` with `opencv-python-headless` to remove the dependency on GUI-related libraries (see: https://github.com/opencv/opencv-python/issues/370#issuecomment-671202529).
I tested this working on the `python:3.9` Docker image.