### PR TITLE
Unable to use img2dataset to download laion-high-resolution without install chardet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ albumentations>=1.1.0,<2
 dataclasses>=0.6,<1.0.0
 wandb>=0.12.10,<0.13
 fsspec==2022.11.0
+chardet==5.1.0


### PR DESCRIPTION
As per the README.md, i installed img2daataset by `pip install img2dataset`, which install `v1.41.0` and tried to download the laion-high-resolution dataset with the following command from the examples:

```sh
img2dataset --url_list laion-high-resolution --input_format "parquet"\
         --url_col "URL" --caption_col "TEXT" --output_format webdataset\
           --output_folder laion-high-resolution-output --processes_count 16 --thread_count 64 --image_size 1024\
            --resize_only_if_bigger=True --resize_mode="keep_ratio" --skip_reencode=True \
             --save_additional_columns '["similarity","hash","punsafe","pwatermark","LANGUAGE"]' --enable_wandb True

```
**I got a missing import error for chardet.** 

Resolution, to include the chardet to the requirements.txt.