### PR TITLE
Correct webp lossless statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Notes:
 
 * jpeg at quality 100 is NOT lossless
 * png format is lossless
-* webp at quality 100 is lossless
+* webp at quality >100 is lossless ([see OpenCV Docs](https://docs.opencv.org/3.4/d8/d6a/group__imgcodecs__flags.html))
 * same quality scale between formats does not mean same image quality
 
 ## Filtering the dataset


### PR DESCRIPTION
Closes #288 

I tried to estimate the space requirements, but my results for other formats did not match those in the table. It's probably best to use the same settings that were used for the other encodings.