### PR TITLE
Set a user agent string that matches convention used by libraries/tools

### DIFF
--- a/img2dataset/downloader.py
+++ b/img2dataset/downloader.py
@@ -38,9 +38,10 @@ def download_image(row, timeout, user_agent_token, disallowed_header_directives)
     """Download an image with urllib"""
     key, url = row
     img_stream = None
-    user_agent_string = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:72.0) Gecko/20100101 Firefox/72.0"
+    user_agent_string = "img2dataset/1.x ("
     if user_agent_token:
-        user_agent_string += f" (compatible; {user_agent_token}; +https://github.com/rom1504/img2dataset)"
+        user_agent_string += f"compatible; {user_agent_token}; "
+    user_agent_string += "+https://github.com/rom1504/img2dataset)"
     try:
         request = urllib.request.Request(url, data=None, headers={"User-Agent": user_agent_string})
         with urllib.request.urlopen(request, timeout=timeout) as r:


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent#library_and_net_tool_ua_strings provides a few examples, also see urllib which uses "Python-urllib/<version>".

img2dataset does not parse HTML so has no reason to pass a user-agent that indicates mozilla compatibility.