### PR TITLE
Remove tmp_dir only if the output dir is not in s3

### DIFF
--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -256,7 +256,7 @@ def download(
     )
     logger_process.join()
 
-    if fs.protocol == "file":
+    if not hasattr(fs, 's3'):
         fs.rm(tmp_dir, recursive=True)
 
 

--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -256,7 +256,7 @@ def download(
     )
     logger_process.join()
 
-    if not hasattr(fs, 's3'):
+    if not hasattr(fs, "s3"):
         fs.rm(tmp_dir, recursive=True)
 
 

--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -255,7 +255,9 @@ def download(
         max_shard_retry,
     )
     logger_process.join()
-    fs.rm(tmp_dir, recursive=True)
+
+    if fs.protocol == "file":
+        fs.rm(tmp_dir, recursive=True)
 
 
 def main():


### PR DESCRIPTION
When not running local, do not remove the tmp_dir, it will be deleted by the last removal of the shard file from the tmp dir.

Fixes #319 