### PR TITLE
support more intput formats (txt.gz, csv.gz, json.gz, jsonl, jsonl.gz) and add test cases for it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ test_folder
 wandb
 *.pex
 .pexing
+build
+.hypothesis

--- a/README.md
+++ b/README.md
@@ -137,10 +137,15 @@ This module exposes a single function `download` which takes the same arguments 
   * **dummy** does not save. Useful for benchmarks
 * **input_format** decides how to load the urls (default *txt*)
   * **txt** loads the urls as a text file of url, one per line
+  * **txt.gz** loads the urls as a compressed (gzip) txt.gz with a list of url, one per line
   * **csv** loads the urls and optional caption as a csv
+  * **csv.gz** loads the urls and optional caption, as a compressed (gzip) csv.gz
   * **tsv** loads the urls and optional caption as a tsv
-  * **tsv.gz** loads the urls and optional caption as a compressed (gzip) tsv.gz
+  * **tsv.gz** loads the urls and optional caption, as a compressed (gzip) tsv.gz
   * **json** loads the urls and optional caption as a json
+  * **json.gz** loads the urls and optional caption, as a compressed (gzip) json.gz
+  * **jsonl** loads the urls and optional caption as a jsonl. see [jsonlines](https://jsonlines.org/) for more
+  * **jsonl.gz** loads the urls and optional caption, as a compressed (gzip) jsonl.gz. see [jsonlines](https://jsonlines.org/) for more
   * **parquet** loads the urls and optional caption as a parquet
 * **url_col** the name of the url column for parquet and csv (default *url*)
 * **caption_col** the name of the caption column for parquet and csv (default *None*)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,6 +4,7 @@ import glob
 import random
 import os
 import sys
+import gzip
 
 
 def setup_fixtures(count=5, disallowed=0):
@@ -35,30 +36,34 @@ def setup_fixtures(count=5, disallowed=0):
     return test_list
 
 
-def generate_url_list_txt(output_file, test_list):
-    with open(output_file, "w") as f:
+def generate_url_list_txt(output_file, test_list, compression_on=False):
+    if compression_on:
+        f = gzip.open(output_file, 'wt')
+    else:
+        f = open(output_file, "w")
+    with f:
         for _, url in test_list:
             f.write(url + "\n")
 
 
-def generate_csv(output_file, test_list):
+def generate_csv(output_file, test_list, compression=None):
     df = pd.DataFrame(test_list, columns=["caption", "url"])
-    df.to_csv(output_file)
+    df.to_csv(output_file, compression=compression)
 
 
-def generate_tsv(output_file, test_list):
+def generate_tsv(output_file, test_list, compression=None):
     df = pd.DataFrame(test_list, columns=["caption", "url"])
-    df.to_csv(output_file, sep="\t")
+    df.to_csv(output_file, sep="\t", compression=compression)
 
 
-def generate_tsv_gz(output_file, test_list):
+def generate_json(output_file, test_list, compression=None):
     df = pd.DataFrame(test_list, columns=["caption", "url"])
-    df.to_csv(output_file, sep="\t", compression="gzip")
+    df.to_json(output_file, compression=compression)
 
 
-def generate_json(output_file, test_list):
+def generate_jsonl(output_file, test_list, compression=None):
     df = pd.DataFrame(test_list, columns=["caption", "url"])
-    df.to_json(output_file)
+    df.to_json(output_file, orient='records', lines=True, compression=compression)
 
 
 def generate_parquet(output_file, test_list):
@@ -70,18 +75,33 @@ def generate_input_file(input_format, url_list_name, test_list):
     if input_format == "txt":
         url_list_name += ".txt"
         generate_url_list_txt(url_list_name, test_list)
+    elif input_format == "txt.gz":
+        url_list_name += ".txt.gz"
+        generate_url_list_txt(url_list_name, test_list, True)
     elif input_format == "csv":
         url_list_name += ".csv"
         generate_csv(url_list_name, test_list)
+    elif input_format == "csv.gz":
+        url_list_name += ".csv.gz"
+        generate_csv(url_list_name, test_list, "gzip")
     elif input_format == "tsv":
         url_list_name += ".tsv"
         generate_tsv(url_list_name, test_list)
     elif input_format == "tsv.gz":
         url_list_name += ".tsv.gz"
-        generate_tsv_gz(url_list_name, test_list)
+        generate_tsv(url_list_name, test_list, "gzip")
     elif input_format == "json":
         url_list_name += ".json"
         generate_json(url_list_name, test_list)
+    elif input_format == "json.gz":
+        url_list_name += ".json.gz"
+        generate_json(url_list_name, test_list, "gzip")
+    elif input_format == "jsonl":
+        url_list_name += ".jsonl"
+        generate_jsonl(url_list_name, test_list)
+    elif input_format == "jsonl.gz":
+        url_list_name += ".jsonl.gz"
+        generate_jsonl(url_list_name, test_list, "gzip")
     elif input_format == "parquet":
         url_list_name += ".parquet"
         generate_parquet(url_list_name, test_list)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -75,14 +75,24 @@ def test_download_resize(image_size, resize_mode, resize_only_if_bigger, skip_re
     [
         ["txt", "files"],
         ["txt", "webdataset"],
+        ["txt.gz", "files"],
+        ["txt.gz", "webdataset"],
         ["csv", "files"],
         ["csv", "webdataset"],
+        ["csv.gz", "files"],
+        ["csv.gz", "webdataset"],
         ["tsv", "files"],
         ["tsv", "webdataset"],
         ["tsv.gz", "files"],
         ["tsv.gz", "webdataset"],
         ["json", "files"],
         ["json", "webdataset"],
+        ["json.gz", "files"],
+        ["json.gz", "webdataset"],
+        ["jsonl", "files"],
+        ["jsonl", "webdataset"],
+        ["jsonl.gz", "files"],
+        ["jsonl.gz", "webdataset"],
         ["parquet", "files"],
         ["parquet", "webdataset"],
         ["parquet", "parquet"],
@@ -129,7 +139,7 @@ def test_download_input_format(input_format, output_format, tmp_path):
             "md5",
         ]
 
-        if input_format != "txt":
+        if input_format not in ["txt", "txt.gz"]:
             expected_columns.insert(2, "caption")
 
         if output_format == "parquet":
@@ -159,7 +169,7 @@ def test_download_input_format(input_format, output_format, tmp_path):
 
         assert len(pd.read_parquet(image_folder_name + "/00000.parquet").index) == expected_file_count
     elif output_format == "dummy":
-        l = [x for x in glob.glob(image_folder_name + "/*") if not x.endswith(".json")]
+        l = [x for x in glob.glob(image_folder_name + "/*") if (not x.endswith(".json") and not x.endswith(".jsonl") and not x.endswith(".json.gz") and not x.endswith(".jsonl.gz")) ]
         assert len(l) == 0
     elif output_format == "tfrecord":
         l = glob.glob(image_folder_name + "/*.tfrecord")
@@ -173,14 +183,24 @@ def test_download_input_format(input_format, output_format, tmp_path):
     [
         ["txt", "files"],
         ["txt", "webdataset"],
+        ["txt.gz", "files"],
+        ["txt.gz", "webdataset"],
         ["csv", "files"],
         ["csv", "webdataset"],
+        ["csv.gz", "files"],
+        ["csv.gz", "webdataset"],
         ["tsv", "files"],
         ["tsv", "webdataset"],
         ["tsv.gz", "files"],
         ["tsv.gz", "webdataset"],
         ["json", "files"],
         ["json", "webdataset"],
+        ["json.gz", "files"],
+        ["json.gz", "webdataset"],
+        ["jsonl", "files"],
+        ["jsonl", "webdataset"],
+        ["jsonl.gz", "files"],
+        ["jsonl.gz", "webdataset"],
         ["parquet", "files"],
         ["parquet", "webdataset"],
     ],

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -17,10 +17,15 @@ def current_memory_usage():
     "input_format",
     [
         "txt",
+        "txt.gz",
         "csv",
+        "csv.gz",
         "tsv",
         "tsv.gz",
         "json",
+        "json.gz",
+        "jsonl",
+        "jsonl.gz",
         "parquet",
     ],
 )
@@ -42,7 +47,7 @@ def test_reader(input_format, tmp_path):
         url_list=url_list_name,
         input_format=input_format,
         url_col="url",
-        caption_col=None if input_format == "txt" else "caption",
+        caption_col=None if input_format in ["txt", "txt.gz"] else "caption",
         verify_hash_col=None,
         verify_hash_type=None,
         save_additional_columns=None,
@@ -51,7 +56,7 @@ def test_reader(input_format, tmp_path):
         tmp_path=test_folder,
     )
 
-    if input_format == "txt":
+    if input_format in ["txt", "txt.gz"]:
         assert reader.column_list == ["url"]
     else:
         assert reader.column_list == ["caption", "url"]
@@ -75,7 +80,7 @@ def test_reader(input_format, tmp_path):
         end_expected = (incremental_shard_id + 1) * batch_size
 
         expected_shard = list(enumerate(test_list[begin_expected:end_expected]))
-        if input_format == "txt":
+        if input_format in ["txt", "txt.gz"]:
             expected_shard = [(i, (url,)) for i, (_, url) in expected_shard]
         assert shard == expected_shard
         current_usage = current_memory_usage()


### PR DESCRIPTION
Full Test Pass for the change:

[img2dataset.add-more-input-formts.all-test-pass.log](https://github.com/rom1504/img2dataset/files/11918350/img2dataset.add-more-input-formts.all-test-pass.log)
