### PR TITLE
fix int conversion failure caused by macos hidden file in logger.py

### DIFF
--- a/img2dataset/logger.py
+++ b/img2dataset/logger.py
@@ -236,7 +236,12 @@ class LoggerProcess(multiprocessing.context.SpawnProcess):
                 stats_files = fs.glob(output_path + "/*.json")
 
                 # filter out files that have an id smaller that are already done
-                stats_files = [f for f in stats_files if int(f.split("/")[-1].split("_")[0]) not in self.done_shards]
+                stats_files = [
+                    f
+                    for f in stats_files
+                    if not f.split("/")[-1].startswith("._")
+                    and int(f.split("/")[-1].split("_")[0]) not in self.done_shards
+                ]
 
                 # get new stats files
                 new_stats_files = set(stats_files) - self.stats_files


### PR DESCRIPTION
#311 
If there were macos generated system files that start with "._" and end with ".json", int() would throw exception and cause logger exit. A small fix to filtering will solve this.