### PR TITLE
[BUGFIX] .txt file with commas in URLs

### DIFF
--- a/img2dataset/reader.py
+++ b/img2dataset/reader.py
@@ -94,7 +94,7 @@ class Reader:
                 compression = "gzip"
             with self.fs.open(input_file, encoding="utf-8", mode="rb", compression=compression) as file:
                 if self.input_format in ["txt", "txt.gz"]:
-                    df = csv_pa.read_csv(file, read_options=csv_pa.ReadOptions(column_names=["url"]))
+                    df = pa.Table.from_pandas(pd.DataFrame({"url" : file.read().decode().splitlines()}))
                 elif self.input_format in ["json", "json.gz"]:
                     df = pa.Table.from_pandas(pd.read_json(file))
                 elif self.input_format in ["csv", "csv.gz"]:


### PR DESCRIPTION
The current implementation seems to fail when the URLs in a `.txt` input file have commas in them.  This modification seems to fix the bug.

(Disclaimer: I am not 100% I am passing data the way that's intended ... if so, my mistake and please correct me!)