### PR TITLE
Add support for cropping MidJourney style 4x4 grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,8 @@ When both these options are enabled, the only bottlenecks left are network relat
 ## File system support
 
 Thanks to [fsspec](https://filesystem-spec.readthedocs.io/en/latest/), img2dataset supports reading and writing files in [many file systems](https://github.com/fsspec/filesystem_spec/blob/6233f315548b512ec379323f762b70764efeb92c/fsspec/registry.py#L87).
-To use it, simply use the prefix of your filesystem before the path. For example `hdfs://`, `s3://`, `http://`, or `gcs://`.
-Some of these file systems require installing an additional package (for example s3fs for s3, gcsfs for gcs).
+To use it, simply use the prefix of your filesystem before the path. For example `hdfs://`, `s3://`, `http://`, `gcs://` or `ssh://`.
+Some of these file systems require installing an additional package (for example s3fs for s3, gcsfs for gcs, [fsspec/sshfs](https://github.com/fsspec/sshfs) for ssh).
 See fsspec doc for all the details.
 
 If you need specific configuration for your filesystem, you may handle this problem by using the [fsspec configuration system](https://filesystem-spec.readthedocs.io/en/latest/features.html#configuration) that makes it possible to create a file such as `.config/fsspec/s3.json` and have information in it such as:

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ This module exposes a single function `download` which takes the same arguments 
 * **output_folder** The path to the output folder. (default *"images"*)
 * **processes_count** The number of processes used for downloading the pictures. This is important to be high for performance. (default *1*)
 * **thread_count** The number of threads used for downloading the pictures. This is important to be high for performance. (default *256*)
+* **crop_mode** The way to crop pictures
+  * **no** doesn't crop at all (default)
+  * **field** crops based on the `crop` field. can be "top-right", "top-left", "bottom-left", or "bottom-right"
 * **resize_mode** The way to resize pictures, can be no, border or keep_ratio (default *border*)
   * **no** doesn't resize at all
   * **border** will make the image image_size x image_size and add a border

--- a/examples/test_coco_mds/download_mds.sh
+++ b/examples/test_coco_mds/download_mds.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+export GOOGLE_APPLICATION_CREDENTIALS='/shared_data/shared/gcs_mosaic_streamingdataset_readwrite_svc_acct_creds.json' 
+export GCS_KEYS_JSON='/shared_data/shared/gcs_mosaic_streamingdataset_readwrite_keys.json'
+
+img2dataset \
+    --url_list mscoco.parquet \
+    --input_format "parquet" \
+    --url_col "URL" \
+    --caption_col "TEXT" \
+    --output_format mosaicstreaming \
+    --output_folder gs://pai-datasets-private/test-img2dataset/coco/ \
+    --temp_download_folder ./tmp_coco_mds \
+    --processes_count 4 \
+    --thread_count 8 \
+    --image_size 256 \
+    --resize_only_if_bigger=True \
+    --resize_mode "keep_ratio" \
+    --skip_reencode=True \
+    --enable_wandb False \
+
+    

--- a/examples/test_coco_mds/download_mds.sh
+++ b/examples/test_coco_mds/download_mds.sh
@@ -9,7 +9,7 @@ img2dataset \
     --url_col "URL" \
     --caption_col "TEXT" \
     --output_format mosaicstreaming \
-    --output_folder gs://pai-datasets-private/test-img2dataset/coco/ \
+    --output_folder gs://pai-datasets-private/test-img2dataset/coco \
     --temp_download_folder ./tmp_coco_mds \
     --processes_count 4 \
     --thread_count 8 \

--- a/img2dataset/downloader.py
+++ b/img2dataset/downloader.py
@@ -187,6 +187,7 @@ class Downloader:
         failed_to_resize = 0
         url_indice = self.column_list.index("url")
         caption_indice = self.column_list.index("caption") if "caption" in self.column_list else None
+        crop_indice = self.column_list.index("crop") if "crop" in self.column_list else None
         hash_indice = (
             self.column_list.index(self.verify_hash_type) if self.verify_hash_type in self.column_list else None
         )
@@ -249,6 +250,8 @@ class Downloader:
                     if self.compute_hash is not None:
                         meta[self.compute_hash] = None
 
+                    maybe_crop = sample_data[crop_indice] if crop_indice is not None else None
+
                     if error_message is not None:
                         failed_to_download += 1
                         status = "failed_to_download"
@@ -292,7 +295,7 @@ class Downloader:
                         original_width,
                         original_height,
                         error_message,
-                    ) = self.resizer(img_stream, bbox_list)
+                    ) = self.resizer(img_stream, bbox_list, maybe_crop)
                     if error_message is not None:
                         failed_to_resize += 1
                         status = "failed_to_resize"

--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -133,7 +133,11 @@ def download(
 
     if temp_download_folder is None:
         temp_download_folder = output_folder + "/_tmp"
+    
+    temp_download_folder = make_path_absolute(temp_download_folder)
+
     fs, tmp_dir = fsspec.core.url_to_fs(temp_download_folder)
+ 
     if not fs.exists(tmp_dir):
         fs.mkdir(tmp_dir)
 
@@ -268,7 +272,7 @@ def download(
     logger_process.join()
 
     if not hasattr(fs, "s3"):
-        fs.rm(tmp_dir, recursive=True)
+        fs.rmdir(tmp_dir)
 
 
 def main():

--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -26,6 +26,10 @@ import sys
 import signal
 import os
 
+import ssl
+# Hack: disable SSL verification to enable running under slurm
+ssl._create_default_https_context = ssl._create_unverified_context
+
 logging.getLogger("exifread").setLevel(level=logging.CRITICAL)
 
 

--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -82,6 +82,7 @@ def download(
     temp_download_folder: Optional[str] = None,
     processes_count: int = 1,
     resize_mode: str = "border",
+    crop_mode: str = "no",
     resize_only_if_bigger: bool = False,
     upscale_interpolation: str = "lanczos",
     downscale_interpolation: str = "area",
@@ -223,6 +224,7 @@ def download(
     resizer = Resizer(
         image_size=image_size,
         resize_mode=resize_mode,
+        crop_mode=crop_mode,
         resize_only_if_bigger=resize_only_if_bigger,
         upscale_interpolation=upscale_interpolation,
         downscale_interpolation=downscale_interpolation,

--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -17,6 +17,7 @@ from .writer import (
 from .reader import Reader
 from .downloader import Downloader
 from .distributor import (
+    single_process_distributor,
     multiprocessing_distributor,
     pyspark_distributor,
     ray_distributor,
@@ -259,7 +260,9 @@ def download(
     )
 
     print("Starting the downloading of this file")
-    if distributor == "multiprocessing":
+    if distributor == "single_process":
+        distributor_fn = single_process_distributor
+    elif distributor == "multiprocessing":
         distributor_fn = multiprocessing_distributor
     elif distributor == "pyspark":
         distributor_fn = pyspark_distributor

--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -200,6 +200,7 @@ def download(
         number_sample_per_shard,
         done_shards,
         temp_download_folder,
+        crop_mode,
     )
 
     if output_format == "webdataset":

--- a/img2dataset/reader.py
+++ b/img2dataset/reader.py
@@ -25,6 +25,7 @@ class Reader:
     - save_additional_columns: the list of additional columns to save
     - number_sample_per_shard: the number of samples per shard
     - done_shards: a set of already done shards
+    - crop_mode: the crop mode
     """
 
     def __init__(
@@ -39,6 +40,7 @@ class Reader:
         number_sample_per_shard,
         done_shards,
         tmp_path,
+        crop_mode,
     ) -> None:
         self.input_format = input_format
         self.url_col = url_col
@@ -48,6 +50,7 @@ class Reader:
         self.save_additional_columns = save_additional_columns
         self.number_sample_per_shard = number_sample_per_shard
         self.done_shards = done_shards
+        self.crop_mode = crop_mode
 
         fs, url_path = fsspec.core.url_to_fs(url_list)
         self.fs = fs
@@ -74,6 +77,8 @@ class Reader:
             self.column_list = self.column_list + ["url"]
         else:
             raise ValueError(f"Invalid input format {self.input_format}")
+        if self.crop_mode is not None:
+            self.column_list.append("crop")
 
     def _save_to_arrow(self, input_file, start_shard_id):
         """Read the input file and save to arrow files in a temporary directory"""
@@ -114,6 +119,8 @@ class Reader:
                     columns_to_read += [self.verify_hash_col]
                 if self.save_additional_columns is not None:
                     columns_to_read += self.save_additional_columns
+                if self.crop_mode is not None:
+                    columns_to_read += ["crop"]
                 df = pq.read_table(file, columns=columns_to_read)
         else:
             raise ValueError(f"Unknown input format {self.input_format}")

--- a/img2dataset/resizer.py
+++ b/img2dataset/resizer.py
@@ -169,14 +169,6 @@ class Resizer:
                     img = np.rint(img.clip(min=0, max=255)).astype(np.uint8)
                     encode_needed = True
                 original_height, original_width = img.shape[:2]
-                # check if image is too small
-                if min(original_height, original_width) < self.min_image_size:
-                    return None, None, None, None, None, "image too small"
-                if original_height * original_width > self.max_image_area:
-                    return None, None, None, None, None, "image area too large"
-                # check if wrong aspect ratio
-                if max(original_height, original_width) / min(original_height, original_width) > self.max_aspect_ratio:
-                    return None, None, None, None, None, "aspect ratio too large"
 
                 # check if resizer was defined during init if needed
                 if blurring_bbox_list is not None and self.blurrer is None:
@@ -210,6 +202,15 @@ class Resizer:
                     encode_needed = True
                     maybe_blur_still_needed = False
                     original_height, original_width = height, width
+
+                # check if image is too small
+                if min(original_height, original_width) < self.min_image_size:
+                    return None, None, None, None, None, "image too small"
+                if original_height * original_width > self.max_image_area:
+                    return None, None, None, None, None, "image area too large"
+                # check if wrong aspect ratio
+                if max(original_height, original_width) / min(original_height, original_width) > self.max_aspect_ratio:
+                    return None, None, None, None, None, "aspect ratio too large"
 
                 # resizing in following conditions
                 if self.resize_mode in (ResizeMode.keep_ratio, ResizeMode.center_crop):

--- a/img2dataset/resizer.py
+++ b/img2dataset/resizer.py
@@ -189,7 +189,6 @@ class Resizer:
                 if self.crop_mode == CropMode.field and maybe_crop is not None:
                     if blurring_bbox_list is not None and self.blurrer is not None:
                         img = self.blurrer(img=img, bbox_list=blurring_bbox_list)
-                    img = A.random_crop(img, self.image_size, self.image_size)
                     # maybe_crop can be top-left, top-right, bottom-left, bottom-right
                     width = int(img.shape[1] / 2)
                     height = int(img.shape[0] / 2)
@@ -198,13 +197,13 @@ class Resizer:
                         img = img[:height, :width]
                     elif maybe_crop == "top-right":
                         # crop to the top-right quadrant
-                        img = img[width:2 * width, :height]
+                        img = img[:height, width:2 * width]
                     elif maybe_crop == "bottom-left":
                         # crop to the bottom-left quadrant
-                        img = img[:width, height:2 * height]
+                        img = img[height:2 * height, :width]
                     elif maybe_crop == "bottom-right":
                         # crop to the bottom-right quadrant
-                        img = img[width:2 * width, height:2 * height]
+                        img = img[height:2 * height, width:2 * width]
                     else:
                         raise ValueError(f"Invalid crop mode: {maybe_crop}")
 

--- a/img2dataset/writer.py
+++ b/img2dataset/writer.py
@@ -345,6 +345,8 @@ class MosaicStreamingWriter:
     def pyarrow_schema_to_mds_columns(self, schema):
         PYARROW_TYPE_TO_MDS_TYPE = {
             pa.string(): "str",
+            pa.float32(): "float32",
+            pa.float64(): "float64",
         }
 
         return {field.name: PYARROW_TYPE_TO_MDS_TYPE.get(field.type, str(field.type)) for field in schema}

--- a/img2dataset/writer.py
+++ b/img2dataset/writer.py
@@ -328,6 +328,7 @@ class MosaicStreamingWriter:
         self.mdswriter = MDSWriter(
             out=f"{output_folder}/{shard_name}",
             columns=self.mds_columns,
+            size_limit=None, # follow main parameter on # of shards
         )
 
     def set_gcp_credentials_in_environ(self):


### PR DESCRIPTION
In order to use this, make sure to

1. Have a `crop` field in the source dataset (e.g. the source parquet file).  Current supported values are `top-left`, `top-right`, `bottom-left` and `bottom-right`).
2. Pass `--crop_mode field` to `img2dataset` and make sure you are NOT passing `--disable_all_reencoding true`.