### PR TITLE
Added new parameter 'compute_key'

### DIFF
--- a/img2dataset/main.py
+++ b/img2dataset/main.py
@@ -108,6 +108,7 @@ def download(
     max_shard_retry: int = 1,
     user_agent_token: Optional[str] = None,
     disallowed_header_directives: Optional[List[str]] = None,
+    compute_key: Optional[callable] = None,
 ):
     """Download is the main entry point of img2dataset, it uses multiple processes and download multiple files"""
     if disallowed_header_directives is None:
@@ -247,6 +248,7 @@ def download(
         user_agent_token=user_agent_token,
         disallowed_header_directives=disallowed_header_directives,
         blurring_bbox_col=bbox_col,
+        compute_key=compute_key,
     )
 
     print("Starting the downloading of this file")


### PR DESCRIPTION
Added a new parameter 'compute_key', that allows users to override the default function for computing a sample key (compute_key). This should allow finer control of the output format of the downloaded dataset. 

An example use case is the following:

If the dataset had some additional_data which was specified, one of which was a uid across the dataset, a user could simply do the following:
```python
def compute_key(key, shard_id, oom_sample_per_shard, oom_shard_count, additional_columns):
    return str(additional_columns['uid'])
```

Then pass this function to the downloader. Hence changing the default output from:
* output_folder
    * 00000
        * 000000000.jpg
        * 000000000.txt
        * 000000001.jpg
        ...
To:
* output_folder
    * 00000
        * *some_uid_1*.jpg
        * *some_uid_1*.txt
        * *some_uid_2*.jpg
        ...


As far as I am aware this customization still aligns with Web-dataset principles. 