### PR TITLE
Fix usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ See options below.
 First get some image url list. For example:
 
 ```bash
-echo 'https://placekitten.com/200/305' >> myimglist.txt
-echo 'https://placekitten.com/200/304' >> myimglist.txt
-echo 'https://placekitten.com/200/303' >> myimglist.txt
+echo 'https://picsum.photos/200/305' >> myimglist.txt
+echo 'https://picsum.photos/200/304' >> myimglist.txt
+echo 'https://picsum.photos/200/303' >> myimglist.txt
 ```
 
 Then, run the tool:


### PR DESCRIPTION
Replaces placekitten.com example images with picsum.photos to  avoid 500 errors from placekitten.

Fixes #415