### PR TITLE
[DRAFT] feat: allow fixed resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ This module exposes a single function `download` which takes the same arguments 
   * **keep_ratio** will keep the ratio and make the smallest side of the picture image_size
   * **keep_ratio_largest** will keep the ratio and make the largest side of the picture image_size
   * **center_crop** will keep the ratio and center crop the largest side so the picture is squared
+  * **fixed** will resize both sides to image_size so the picture is squared
 * **resize_only_if_bigger** resize pictures only if bigger that the image_size (default *False*)
 * **upscale_interpolation** kind of upscale interpolation used for resizing (default *"lanczos"*)
 * **downscale_interpolation** kind of downscale interpolation used for resizing (default *"area"*)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -122,7 +122,7 @@ def check_one_image_size(img, img_unresized, image_size, resize_mode, resize_onl
     if resize_only_if_bigger:
         if (
             max(width_unresized, height_unresized) <= image_size
-            and resize_mode == "border"
+            and resize_mode in ["border", "fixed"]
             or min(width_unresized, height_unresized) <= image_size
             and resize_mode in ["keep_ratio", "center_crop"]
         ):
@@ -137,7 +137,7 @@ def check_one_image_size(img, img_unresized, image_size, resize_mode, resize_onl
     if not resized:
         return
 
-    if resize_mode == "border":
+    if resize_mode in ["border", "fixed"]:
         if width != image_size or height != image_size:
             raise Exception(f"Image size is not 256x256 in border mode found={width}x{height}")
     elif resize_mode == "keep_ratio":


### PR DESCRIPTION
This would allow resizing to fixed size for example 256x256.

The interest is when training on large datasets (CLIP models for example), if we only need a certain size then we may as well directly download to that target and limit storage requirements.